### PR TITLE
Thread safe http reporting in v0.16

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,27 @@
 PATH
   remote: .
   specs:
-    lightstep (0.16.0)
+    lightstep (0.16.0.pre.github)
       concurrent-ruby (~> 1.0)
       opentracing (~> 0.5.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (6.0.3.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
     bump (0.6.1)
-    concurrent-ruby (1.1.5)
+    concurrent-ruby (1.1.7)
     diff-lcs (1.3)
     docile (1.3.2)
+    i18n (1.8.5)
+      concurrent-ruby (~> 1.0)
     json (2.2.0)
+    minitest (5.14.2)
     opentracing (0.5.0)
     rack (2.0.7)
     rake (11.3.0)
@@ -34,12 +43,17 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    thread_safe (0.3.6)
     timecop (0.8.1)
+    tzinfo (1.2.8)
+      thread_safe (~> 0.1)
+    zeitwerk (2.4.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport (~> 6.0)
   bump (~> 0.5)
   lightstep!
   rack (~> 2.0)
@@ -49,4 +63,4 @@ DEPENDENCIES
   timecop (~> 0.8.0)
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/lib/lightstep.rb
+++ b/lib/lightstep.rb
@@ -45,6 +45,7 @@ module LightStep
   end
 end
 
+require 'lightstep/instrumentation'
 require 'lightstep/tracer'
 require 'lightstep/global_tracer'
 require 'lightstep/scope'

--- a/lib/lightstep/instrumentation.rb
+++ b/lib/lightstep/instrumentation.rb
@@ -1,0 +1,41 @@
+module LightStep
+  # Instrument an operation. This is may be called by any LightStep component to
+  # record an instrumentation event. This is a compatible API to
+  # ActiveSupport::Notifications.
+  #
+  # event   - Name of the event as a symbol. The event is published under the
+  #           lightstep namespace automatically.
+  # payload - Hash payload for the event. Available keys are based on the event
+  #           being published.
+  #
+  # Returns the result of executing the block.
+  def self.instrument(event, payload = {}, &block)
+    if @instrumenter
+      block ||= proc {}
+      @instrumenter.instrument("#{event}.lightstep", payload, &block)
+    elsif block
+      block.call(payload)
+    end
+  end
+
+  # The object that receives instrument messages. This is AS::Notifications by
+  # default but may be set to any object that responds to #instrument.
+  #
+  # Returns an object that responds to #instrument or nil if no instrumentation
+  # backend is configured.
+  def self.instrumenter
+    @instrumenter
+  end
+
+  # Configure the instrumentation backend that will receive events. The object
+  # must respond to #instrument.
+  def self.instrumenter=(object)
+    @instrumenter = object
+  end
+
+  # If AS::Notifications is available, use it as the instrumentation backend by
+  # default. Set LightStep.instrumenter = nil explicitly to disable this.
+  if defined?(ActiveSupport::Notifications)
+    @instrumenter = ActiveSupport::Notifications
+  end
+end

--- a/lib/lightstep/reporter.rb
+++ b/lib/lightstep/reporter.rb
@@ -78,7 +78,9 @@ module LightStep
       @report_start_time = now
 
       begin
-        @transport.report(report_request)
+        LightStep.instrument("flush", report: report_request) do
+          @transport.report(report_request)
+        end
       rescue StandardError => e
         LightStep.logger.error "LightStep error reporting to collector: #{e.message}"
         # an error occurs, add the previous dropped_spans and count of spans

--- a/lib/lightstep/version.rb
+++ b/lib/lightstep/version.rb
@@ -1,3 +1,3 @@
 module LightStep
-  VERSION = '0.16.0'.freeze
+  VERSION = '0.16.0-github'.freeze
 end

--- a/lightstep.gemspec
+++ b/lightstep.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bump', '~> 0.5'
   spec.add_development_dependency 'simplecov', '~> 0.16'
   spec.add_development_dependency 'timecop', '~> 0.8.0'
-  spec.add_development_dependency 'activesupport', '~> 5.1'
+  spec.add_development_dependency 'activesupport', '~> 6.0'
 end

--- a/lightstep.gemspec
+++ b/lightstep.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bump', '~> 0.5'
   spec.add_development_dependency 'simplecov', '~> 0.16'
   spec.add_development_dependency 'timecop', '~> 0.8.0'
+  spec.add_development_dependency 'activesupport', '~> 5.1'
 end

--- a/spec/http_json_spec.rb
+++ b/spec/http_json_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+require 'thread'
+require 'rack'
+require 'rack/server'
+
+class App
+  attr_reader :mutex, :calls
+
+  def initialize
+    @mutex = Mutex.new
+    @calls = 0
+  end
+
+  def call(env)
+    # Note we are not unlocking...
+    @calls += 1
+
+    @mutex.lock
+    [200, {}, ["application"]]
+  end
+end
+
+
+describe LightStep::Transport::HTTPJSON do
+  it 'requires an access token' do
+    expect { LightStep::Transport::HTTPJSON.new }.to raise_error(ArgumentError)
+  end
+
+  it 'is thread safe' do
+    app = App.new
+    router_thread = Thread.new do
+      Thread.abort_on_exception = true
+      Rack::Server.start(app: app, Port: 9001)
+    end
+
+    # Let the server startup
+    sleep 0.250
+
+    t = LightStep::Transport::HTTPJSON.new host: "127.0.0.1", port: "9001", encryption: false, access_token: "foo"
+
+    app.mutex.lock
+
+    report_a = Thread.new do
+      t.report hello: true
+    end
+
+    report_b = Thread.new do
+      t.report hello: true
+    end
+
+    sleep 0.250
+
+    # Only one thread will have been able to call
+    expect(app.calls).to eq(1)
+
+    router_thread.terminate
+    report_a.terminate
+    report_b.terminate
+  end
+end

--- a/spec/lightstep_spec.rb
+++ b/spec/lightstep_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'active_support/core_ext/object/try'
 
 describe LightStep do
   def init_test_tracer

--- a/spec/lightstep_spec.rb
+++ b/spec/lightstep_spec.rb
@@ -1,4 +1,3 @@
-require 'active_support'
 require 'spec_helper'
 
 describe LightStep do

--- a/spec/lightstep_spec.rb
+++ b/spec/lightstep_spec.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'spec_helper'
 
 describe LightStep do
@@ -670,6 +671,26 @@ describe LightStep do
     records = result[:span_records]
     expect(records[0][:span_name]).to eq("5")
     expect(records[1][:span_name]).to eq("[:foo]")
+  end
+
+  it 'should delivery instrumentation notifications' do
+    tracer = init_test_tracer
+    event_payload = nil
+
+    tracer.start_span('span').finish
+
+    subscription = LightStep.instrumenter.subscribe "flush.lightstep" do |name, start_time, end_time, id, payload|
+      event_payload = payload
+    end
+
+    begin
+      tracer.flush
+    ensure
+      LightStep.instrumenter.unsubscribe subscription
+    end
+
+    expect(event_payload).to be_a(Hash)
+    expect(event_payload[:report][:span_records].length).to eq(1)
   end
 
   describe '#scope_manager' do

--- a/spec/lightstep_spec.rb
+++ b/spec/lightstep_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'active_support/core_ext/object/try'
 
 describe LightStep do
   def init_test_tracer

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@
 require 'simplecov'
 SimpleCov.start
 require 'pp'
+require 'active_support'
 require 'lightstep'
 require 'timecop'
 require 'helpers/rack_helpers'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,7 @@ require 'simplecov'
 SimpleCov.start
 require 'pp'
 require 'active_support'
+require 'active_support/core_ext/object/try'
 require 'lightstep'
 require 'timecop'
 require 'helpers/rack_helpers'


### PR DESCRIPTION
This PR replays changes that introduced thread-safe reporting over persistent connections against upstream v0.16.

It also upgrades the minimum requirement for ActiveSupport to Rails 6.

See https://github.com/github/observability/issues/171