### PR TITLE
Use Keyword Arguments instead of Last Parameter Options

### DIFF
--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -181,7 +181,7 @@ module LightStep
         max_log_records: max_log_records,
       }
 
-      Span.new(span_options).tap do |span|
+      Span.new(**span_options).tap do |span|
         if block_given?
           begin
             return yield span


### PR DESCRIPTION
Ruby 2.7 warning

https://github.com/github/github/pull/163443/checks?check_run_id=1433764823