### PR TITLE
Copy kwargs warning from upstream

### DIFF
--- a/lib/lightstep/tracer.rb
+++ b/lib/lightstep/tracer.rb
@@ -181,7 +181,7 @@ module LightStep
         max_log_records: max_log_records,
       }
 
-      Span.new(span_options).tap do |span|
+      Span.new(**span_options).tap do |span|
         if block_given?
           begin
             return yield span


### PR DESCRIPTION
This fixes kwargs warning:

```
tracer.rb:184: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```